### PR TITLE
Some Changes in AnimeUnity Search and Featured

### DIFF
--- a/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Featured.swift
+++ b/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Featured.swift
@@ -27,7 +27,7 @@ extension NASourceAnimeUnity {
             //div.current-anime>div.row>div a
             let endpointURL = self.endpointURL
             let bowl = try SwiftSoup.parse(responseContent)
-            let popularLinkElements = try bowl.select("div.current-anime>div.row>div>div.text-center a")//"div.current-anime>div.row>div a")
+            let popularLinkElements = try bowl.select("div.current-anime>div.row>div>div.text-center a")
             let recentadded = try bowl.select("div.text-center>div.text-center>div a")
             let recentAnimeLinks = try recentadded.compactMap {
                 aElement -> (a: Element, img: Element)? in
@@ -38,13 +38,13 @@ extension NASourceAnimeUnity {
                 container, elements in
                 if let artworkPath = try? elements.img.attr("src"),
                     let artworkUrl = URL(string: artworkPath, relativeTo: endpointURL),
-                    let animeTitle = try? elements.a.text(),
+                    let animeTitle = (try? elements.a.text())?.components(separatedBy: " - Episodio"),
                     let animePath = try? elements.a.attr("href"),
-                    
+                
                     let animeUrl = URL(string: animePath, relativeTo: endpointURL) {
                     // Construct and add anime link
                     container.append(.init(
-                        title: animeTitle,
+                        title: animeTitle[0],
                         link: animeUrl,
                         image: artworkUrl,
                         source: self

--- a/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Search.swift
+++ b/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Search.swift
@@ -29,6 +29,9 @@ extension NASourceAnimeUnity {
         private let parent: NASourceAnimeUnity
         private var requestTask: NineAnimatorAsyncTask?
         private var _results: [AnimeLink]?
+        private var anno: [AnimeLink]?
+        private var _results_not: [AnimeLink]?
+//        var Year: [Int] = []
         var title: String
         var returned = true
         weak var delegate: ContentProviderDelegate?
@@ -47,9 +50,20 @@ extension NASourceAnimeUnity {
                     do {
                         let bowl = try SwiftSoup.parse(response.debugDescription)
                         let entries = try bowl.select("div.row>div.col-lg-4")
-                        self._results = try entries.compactMap {
+                        self._results_not = try entries.compactMap {
                             entry -> AnimeLink? in
                             let animeTitle = try entry.select("div>h6.card-title>b")
+                            /*
+                             detect the "realease year" and save it into Year array
+                            var year_ex = 0
+                            let anno2 = try entry.select("div.card-block>p.card-text").text()
+                            if(anno2.contains("Anno di uscita:")){
+                                var anno = anno2.components(separatedBy: "Anno di uscita:")
+                                year_ex = Int(anno[1]) ?? 0
+                                
+                            }
+                            self.Year.append(year_ex)
+ */
                             let title = try animeTitle.text()
                             if title.isEmpty { return nil }
                             let animeLinkPath = try entry.select("div>a")
@@ -68,6 +82,7 @@ extension NASourceAnimeUnity {
                                 source: self.parent
                             )
                         }
+                        self._results = self._results_not?.sorted { (lhs, rhs) in return lhs.link.absoluteString < rhs.link.absoluteString }
                         self.delegate?.pageIncoming(0, from: self)
                     } catch {
                         Log.error("[NASourceAnimeUnity.SearchAgent] Unable to perform search operation: %@", error)


### PR DESCRIPTION
Removed ` - Episodio xx` in the name of "recent added", reordered "search" by link.

The order of the search could be better, in the code (commented) there are some lines that detect the year of the season and store them into an array. it would be better to use it but I have not found a way