### PR TITLE
search is now ordered based on release year

### DIFF
--- a/NineAnimator/Models/Anime Source/animeultima.eu/AnimeUltima+Search.swift
+++ b/NineAnimator/Models/Anime Source/animeultima.eu/AnimeUltima+Search.swift
@@ -30,7 +30,9 @@ extension NASourceAnimeUltima {
         var totalPages: Int? = 1
         var availablePages: Int { result == nil ? 0 : 1 }
         var moreAvailable: Bool { result == nil }
-        
+        private var anno: [AnimeLink]?
+        private var _results_not: [AnimeLink]?
+        var Year: [Int] = []
         // The result of the search
         private var result: [AnyLink]?
         private var searchRequestingTask: NineAnimatorAsyncTask?
@@ -60,7 +62,16 @@ extension NASourceAnimeUltima {
                     let animeArtworkString = try resultAnimeContainer.select("img").attr("src")
                     let animeArtworkUrl = try some(URL(string: animeArtworkString), or: .urlError)
                     let animeTitle = try resultAnimeContainer.select("span.anime-title").text()
-                    
+                    /////////////////////////////
+                    //detect the "realease year" and save it into Year array
+                    var year_ex = 0
+                    let anno2 = try resultAnimeContainer.select("span.anime-details.is-size-7.has-text-grey>strong").text()
+                    if anno2.contains(" · ") {
+                        let anno = anno2.components(separatedBy: " · ")
+                        year_ex = Int(anno[1]) ?? 0
+                    }
+                    self.Year.append(year_ex)
+                    /////////////////////////////
                     // Construct anime link and add to list
                     resultingAnime.append(AnimeLink(
                         title: animeTitle,
@@ -69,7 +80,7 @@ extension NASourceAnimeUltima {
                         source: self.parent
                     ))
                 }
-                
+                resultingAnime = zip(self.Year, resultingAnime).sorted { $0.0 < $1.0 }.map { $0.1 }
                 return resultingAnime
             } .error {
                 [weak self] error in

--- a/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Search.swift
+++ b/NineAnimator/Models/Anime Source/animeunity.it/AnimeUnity+Search.swift
@@ -31,7 +31,7 @@ extension NASourceAnimeUnity {
         private var _results: [AnimeLink]?
         private var anno: [AnimeLink]?
         private var _results_not: [AnimeLink]?
-//        var Year: [Int] = []
+        var Year: [Int] = []
         var title: String
         var returned = true
         weak var delegate: ContentProviderDelegate?
@@ -53,17 +53,14 @@ extension NASourceAnimeUnity {
                         self._results_not = try entries.compactMap {
                             entry -> AnimeLink? in
                             let animeTitle = try entry.select("div>h6.card-title>b")
-                            /*
-                             detect the "realease year" and save it into Year array
+//                          detect the "realease year" and save it into Year array
                             var year_ex = 0
                             let anno2 = try entry.select("div.card-block>p.card-text").text()
-                            if(anno2.contains("Anno di uscita:")){
-                                var anno = anno2.components(separatedBy: "Anno di uscita:")
+                            if anno2.contains("Anno di uscita:") {
+                                let anno = anno2.components(separatedBy: "Anno di uscita: ")
                                 year_ex = Int(anno[1]) ?? 0
-                                
                             }
                             self.Year.append(year_ex)
- */
                             let title = try animeTitle.text()
                             if title.isEmpty { return nil }
                             let animeLinkPath = try entry.select("div>a")
@@ -82,7 +79,7 @@ extension NASourceAnimeUnity {
                                 source: self.parent
                             )
                         }
-                        self._results = self._results_not?.sorted { (lhs, rhs) in return lhs.link.absoluteString < rhs.link.absoluteString }
+                        self._results = zip(self.Year, self._results_not ?? []).sorted { $0.0 < $1.0 }.map { $0.1 }
                         self.delegate?.pageIncoming(0, from: self)
                     } catch {
                         Log.error("[NASourceAnimeUnity.SearchAgent] Unable to perform search operation: %@", error)


### PR DESCRIPTION
I successfully did what I wanted, now the search is sorted by release year. 

Maybe it can be brought to other sources that do not do it by default, it would be more "tidy", maybe using MAL because not all sources indicate in the search results the year of release. or more simply order only the result of the sources that indicate it (for example animeultima and 4anime)