### PR TITLE
Update GogoAnime.swift

### DIFF
--- a/NineAnimator/Models/Anime Source/gogoanime/GogoAnime.swift
+++ b/NineAnimator/Models/Anime Source/gogoanime/GogoAnime.swift
@@ -45,7 +45,7 @@ class NASourceGogoAnime: BaseSource, Source, PromiseSource {
         \.english
     }
 
-    override var endpoint: String { "https://gogoanime.io" }
+    override var endpoint: String { "https://gogoanime.video" }
 
     let ajaxEndpoint = URL(string: "https://ajax.apimovie.xyz")!
 


### PR DESCRIPTION
The old domain (.io) doesnt work. If you go to gogoanime.tv, it will redirect you to .video, which is the new domain