### PR TITLE
Fix GogoAnime's streaming source parsing

### DIFF
--- a/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
+++ b/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
@@ -56,7 +56,7 @@ extension NASourceGogoAnime {
                 let bowl = try SwiftSoup.parse(content)
                 
                 // Parse the streaming sources
-                var streamingSources = try bowl.select("div.anime_muti_link a").compactMap {
+                let streamingSources = try bowl.select("div.anime_muti_link a").compactMap {
                     serverLinkContainer -> (String, URL)? in
                     // Remove the "Select this server thing"
                     try serverLinkContainer.select("span").remove()
@@ -66,10 +66,10 @@ extension NASourceGogoAnime {
                         relativeTo: self.endpointURL.appendingPathComponent(episodePath)
                     ) else { return nil }
                     return (serverName, streamUrl)
-                }.filter {
-                    //GogoAnime's "Vidstreaming" server is a collection of backup links to different servers, however there is currently no way for the user to select a backup link, so we are removing this server.
+                } .filter {
+                    // GogoAnime's "Vidstreaming" server is a collection of backup links to different servers, however there is currently no way for the user to select a backup link, so we are removing this server.
 
-                    //Keep in mind that GogoAnime's "Gogo server" does use the VidStreamingParser
+                    // Keep in mind that GogoAnime's "Gogo server" does use the VidStreamingParser
                     $0.0 != "Vidstreaming"
                 }
                 

--- a/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
+++ b/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
@@ -56,7 +56,7 @@ extension NASourceGogoAnime {
                 let bowl = try SwiftSoup.parse(content)
                 
                 // Parse the streaming sources
-                let streamingSources = try bowl.select("div.anime_muti_link a").compactMap {
+                var streamingSources = try bowl.select("div.anime_muti_link a").compactMap {
                     serverLinkContainer -> (String, URL)? in
                     // Remove the "Select this server thing"
                     try serverLinkContainer.select("span").remove()
@@ -72,6 +72,11 @@ extension NASourceGogoAnime {
                 guard !streamingSources.isEmpty else {
                     throw NineAnimatorError.responseError("No streaming sources found for this anime")
                 }
+                
+                //GogoAnime's "Vidstreaming" server is a collection of backup links to different servers, however there is currently no way for the user to select a backup link, so we are removing this server from the Dictionary of sources.
+                
+                //Keep in mind that GogoAnime's "Gogo server" does use the VidStreamingParser
+                streamingSources.removeAll { $0.0 == "Vidstreaming" }
                 
                 // Construct the episode information structure
                 return NAGogoAnimeEpisodeInformation(

--- a/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
+++ b/NineAnimator/Models/Anime Source/gogoanime/GogoAnime+Episode.swift
@@ -66,18 +66,18 @@ extension NASourceGogoAnime {
                         relativeTo: self.endpointURL.appendingPathComponent(episodePath)
                     ) else { return nil }
                     return (serverName, streamUrl)
+                }.filter {
+                    //GogoAnime's "Vidstreaming" server is a collection of backup links to different servers, however there is currently no way for the user to select a backup link, so we are removing this server.
+
+                    //Keep in mind that GogoAnime's "Gogo server" does use the VidStreamingParser
+                    $0.0 != "Vidstreaming"
                 }
                 
                 // Make sure there is any
                 guard !streamingSources.isEmpty else {
                     throw NineAnimatorError.responseError("No streaming sources found for this anime")
                 }
-                
-                //GogoAnime's "Vidstreaming" server is a collection of backup links to different servers, however there is currently no way for the user to select a backup link, so we are removing this server from the Dictionary of sources.
-                
-                //Keep in mind that GogoAnime's "Gogo server" does use the VidStreamingParser
-                streamingSources.removeAll { $0.0 == "Vidstreaming" }
-                
+                                
                 // Construct the episode information structure
                 return NAGogoAnimeEpisodeInformation(
                     path: episodePath,

--- a/NineAnimator/Models/Media/Parser/VidStreamingParser.swift
+++ b/NineAnimator/Models/Media/Parser/VidStreamingParser.swift
@@ -23,7 +23,7 @@ import Foundation
 
 class VidStreamingParser: VideoProviderParser {
     var aliases: [String] {
-        [ "VidStreaming", "VidCDN" ]
+        [ "VidStreaming", "VidCDN", "Gogo Server" ]
     }
     
     private static let videoSourceRegex = try! NSRegularExpression(


### PR DESCRIPTION
- GogoAnime's "Vidstreaming" server will not use the VidStreamingParser anymore, and is removed from the "Select Server" menu

- GogoAnime's "Gogo server" will now use the VidStreamingParser