### PR TITLE
Fix 4anime+Search

### DIFF
--- a/NineAnimator/Models/Anime Source/4anime.to/FourAnime+Search.swift
+++ b/NineAnimator/Models/Anime Source/4anime.to/FourAnime+Search.swift
@@ -56,8 +56,11 @@ extension NASourceFourAnime {
                     return try possibleLinkContainers.reduce(into: [AnimeLink]()) {
                         results, container in
                         if let img = try container.select("img").first() {
+                            let artworkURLString = try img.attr("src")
+                                .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                                .tryUnwrap(.urlError)
                             let artworkUrl = try URL(
-                                string: try img.attr("src")
+                                string: artworkURLString
                             ).tryUnwrap()
                             let animeUrl = try URL(
                                 string: try container.attr("href")


### PR DESCRIPTION
Searching certain anime (Koi to Producer) will no longer fail.