### PR TITLE
Fix 4anime title

### DIFF
--- a/NineAnimator/Models/Anime Source/4anime.to/FourAnime+Anime.swift
+++ b/NineAnimator/Models/Anime Source/4anime.to/FourAnime+Anime.swift
@@ -37,7 +37,7 @@ extension NASourceFourAnime {
                 string: try bowl.select(".cover>img").attr("src"),
                 relativeTo: resolvedAnimeLink.link
             ) ?? resolvedAnimeLink.image
-            let animeTitle = try bowl.select("div#details center").text()
+            let animeTitle = try bowl.select(".content p").text()
             let reconstructedAnimeLink = AnimeLink(
                 title: animeTitle,
                 link: resolvedAnimeLink.link,


### PR DESCRIPTION
Changed `div#details center` to `.content p`

`div#details center` didn't work as there were multiple center elements under `div#details`.