### PR TITLE
Automatically Move User's Anime to their Completed List

### DIFF
--- a/NineAnimator/Models/Anime Listing Service/Anilist/Anilist+AnimeInformation.swift
+++ b/NineAnimator/Models/Anime Listing Service/Anilist/Anilist+AnimeInformation.swift
@@ -144,10 +144,10 @@ extension Anilist {
             
             if let status = mediaEntry["status"] as? String {
                 switch status {
-                case "FINISHED": information["Airing Status"] = "Finished"
-                case "RELEASING": information["Airing Status"] = "Ongoing"
-                case "NOT_YET_RELEASED": information["Airing Status"] = "Not Yet Released"
-                case "CANCELLED": information["Airing Status"] = "Cancelled"
+                case "FINISHED": information["Airing Status"] = AiringStatus.finished.rawValue
+                case "RELEASING": information["Airing Status"] = AiringStatus.currentlyAiring.rawValue
+                case "NOT_YET_RELEASED": information["Airing Status"] = AiringStatus.notReleased.rawValue
+                case "CANCELLED": information["Airing Status"] = AiringStatus.cancelled.rawValue
                 default: break
                 }
             }

--- a/NineAnimator/Models/Anime Listing Service/Anilist/Anilist.swift
+++ b/NineAnimator/Models/Anime Listing Service/Anilist/Anilist.swift
@@ -224,7 +224,7 @@ extension Anilist {
         _mutationRequestReferencePool.append(task)
     }
     
-    private func cleanupReferencePool() {
+    internal func cleanupReferencePool() {
         _mutationRequestReferencePool.removeAll {
             ($0 as! NineAnimatorPromise<NSDictionary>).isResolved
         }

--- a/NineAnimator/Models/Anime Listing Service/Kitsu.io/Kitsu+Mutation.swift
+++ b/NineAnimator/Models/Anime Listing Service/Kitsu.io/Kitsu+Mutation.swift
@@ -66,8 +66,12 @@ extension Kitsu {
         _mutationTaskPool.append(task)
     }
     
-    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?) {
+    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?, shouldUpdateTrackingState: Bool = true) {
         collectMutationTaskPoolGarbage()
+        
+        if shouldUpdateTrackingState {
+            Log.info("[Kitsu.io] Cannot update Tracking State because NineAnimator doesn't support retrieving anime details from Kitsu.")
+        }
         
         // First, get the episode number
         guard let episodeNumber = episodeNumber else {

--- a/NineAnimator/Models/Anime Listing Service/ListingAnimeInformation.swift
+++ b/NineAnimator/Models/Anime Listing Service/ListingAnimeInformation.swift
@@ -40,6 +40,15 @@ struct ListingAnimeName: CustomStringConvertible {
     let native: String
 }
 
+/// Representing the airing status of an anime
+enum AiringStatus: String {
+    case currentlyAiring = "Ongoing"
+    case finished = "Finished"
+    case notReleased = "Not Yet Released"
+    case cancelled = "Cancelled"
+    case unknown = "Unknown Airing Status"
+}
+
 /// Representing a '2D' character in the anime
 struct ListingAnimeCharacter {
     /// Name of the character in the anime

--- a/NineAnimator/Models/Anime Listing Service/ListingService.swift
+++ b/NineAnimator/Models/Anime Listing Service/ListingService.swift
@@ -110,8 +110,10 @@ protocol ListingService: AnyObject {
     ///
     /// The episodeNumber passed in as parameter is not guarenteed to be the furtherest episode
     /// that the user has completed. It is the episode that the user has just finished watching.
+    ///
     /// Only called if the service returns true for `isCapableOfPersistingAnimeState`
-    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?)
+    /// - Parameter shouldUpdateTrackingState: True by Default. Moves the ListingAnimeReference to the user's Completed list if they have finished watching the last episode.
+    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?, shouldUpdateTrackingState: Bool)
     
     /// Retrieve the listing anime from the reference
     ///

--- a/NineAnimator/Models/Anime Listing Service/MyAnimeList/MyAnimeList+AnimeInformation.swift
+++ b/NineAnimator/Models/Anime Listing Service/MyAnimeList/MyAnimeList+AnimeInformation.swift
@@ -122,6 +122,19 @@ extension MyAnimeList {
                 animeInformation["Created At"] = dateFormatter.string(from: createdDate)
             }
             
+            if let airingStatus = animeEntry.valueIfPresent(at: "status", type: String.self) {
+                switch airingStatus {
+                case "finished_airing":
+                    animeInformation["Airing Status"] = AiringStatus.finished.rawValue
+                case "currently_airing":
+                    animeInformation["Airing Status"] = AiringStatus.currentlyAiring.rawValue
+                case "not_yet_aired":
+                    animeInformation["Airing Status"] = AiringStatus.notReleased.rawValue
+                default:
+                    animeInformation["Airing Status"] = AiringStatus.unknown.rawValue
+                }
+            }
+            
             animeInformation["Start Date"] = animeEntry.valueIfPresent(at: "start_date", type: String.self)
             animeInformation["End Date"] = animeEntry.valueIfPresent(at: "end_date", type: String.self)
             animeInformation["Popularity"] = animeEntry.valueIfPresent(at: "popularity", type: Int.self)
@@ -146,7 +159,7 @@ extension MyAnimeList {
     
     func listingAnime(from reference: ListingAnimeReference) -> NineAnimatorPromise<ListingAnimeInformation> {
         apiRequest("/anime/\(reference.uniqueIdentifier)", query: [
-            "fields": "alternative_titles,average_episode_duration,broadcast,created_at,end_date,main_picture,mean,media_type,nsfw,num_scoring_users,popularity,rank,synopsis,title,background,related_anime,related_anime{node{my_list_status{start_date,finish_date}}},num_episodes,start_date"
+            "fields": "alternative_titles,average_episode_duration,broadcast,created_at,end_date,status,main_picture,mean,media_type,nsfw,num_scoring_users,popularity,rank,synopsis,title,background,related_anime,related_anime{node{my_list_status{start_date,finish_date}}},num_episodes,start_date"
         ]).then {
             response in
             guard let animeEntry = response.data.first else {

--- a/NineAnimator/Models/Anime Listing Service/MyAnimeList/MyAnimeList+Mutation.swift
+++ b/NineAnimator/Models/Anime Listing Service/MyAnimeList/MyAnimeList+Mutation.swift
@@ -47,17 +47,11 @@ extension MyAnimeList {
         _mutationTaskPool.append(task)
     }
     
-    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?) {
+    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?, shouldUpdateTrackingState: Bool = true) {
         collectMutationTaskPoolGarbage()
         
         guard let episodeNumber = episodeNumber else {
             Log.info("[MyAnimeList] Not pushing states because episode number cannot be inferred.")
-            return
-        }
-        
-        // No need for update if the previous progress is higher than the current
-        if let previousTracking = progressTracking(for: reference),
-            previousTracking.currentProgress >= episodeNumber {
             return
         }
         
@@ -67,6 +61,27 @@ extension MyAnimeList {
             withUpdatedEpisodeProgress: episodeNumber
         )
         update(reference, newTracking: newTracking)
+        
+        if shouldUpdateTrackingState {
+            let listingInfoTask = self.listingAnime(from: reference)
+            .defer { _ in self.collectMutationTaskPoolGarbage() }
+            .error {
+                Log.error("[MyAnimeList] Failed To Retrieve Anime Listing Information with error: %@", $0)
+            }
+            .finally {
+                [weak self] listingInfo in
+                guard let self = self else { return }
+                // If the anime has finished airing, and the user has completed the last episode, mark the anime as completed
+                if let currentAiringStatus = listingInfo.information["Airing Status"],
+                   currentAiringStatus == AiringStatus.finished.rawValue,
+                   let totalNumOfEpisodes = newTracking.episodes,
+                   totalNumOfEpisodes <= newTracking.currentProgress {
+                    Log.info("[MyAnimeList] User has finished last episode of anime. Moving %@ to completed list.", reference.name)
+                    self.update(reference, newState: .finished)
+                }
+            }
+            _mutationTaskPool.append(listingInfoTask)
+        }
     }
     
     func collectMutationTaskPoolGarbage() {

--- a/NineAnimator/Models/Anime Listing Service/Simkl/Simkl+Mutation.swift
+++ b/NineAnimator/Models/Anime Listing Service/Simkl/Simkl+Mutation.swift
@@ -53,7 +53,12 @@ extension Simkl {
         }
     }
     
-    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?) {
+    func update(_ reference: ListingAnimeReference, didComplete episode: EpisodeLink, episodeNumber: Int?, shouldUpdateTrackingState: Bool = true) {
+        
+        if shouldUpdateTrackingState {
+            Log.info("[Simkl] Cannot update Tracking State because NineAnimator doesn't support retrieving anime details from Simkl.")
+        }
+        
         let task = episodeObjects(forReference: reference).thenPromise {
             episodes -> NineAnimatorPromise<Any> in
             guard let episodeNumber = {

--- a/NineAnimator/Models/TrackingContext.swift
+++ b/NineAnimator/Models/TrackingContext.swift
@@ -218,7 +218,8 @@ class TrackingContext {
                 reference.parentService.update(
                     reference,
                     didComplete: episode,
-                    episodeNumber: self.suggestingEpisodeNumber(for: episode)
+                    episodeNumber: self.suggestingEpisodeNumber(for: episode),
+                    shouldUpdateTrackingState: true
                 )
             }
             


### PR DESCRIPTION
If the user finishes watching the last episode of an anime, move it to their completed list.

Sadly, this feature only works on MyAnimeList and Anilist as it requires retrieving detailed anime information (airing status).

Closes #213 