### PR TITLE
fix(backup-viewer): component missing on prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
-    "@types/lodash": "^4.14.178",
+    "@types/lodash": "^4.14.179",
     "@types/node": "^17.0.21",
     "@vue/component-compiler-utils": "^3.3.0",
     "@vuepress/bundler-vite": "^2.0.0-beta.35",
@@ -28,7 +28,6 @@
     "@kyvg/vue3-notification": "^2.3.4",
     "bplist-creator": "^0.1.0",
     "bplist-parser": "^0.3.1",
-    "stream": "^0.0.2",
     "util": "^0.12.4",
     "vue3-lazyload": "^0.2.5-beta"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,10 +1321,10 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/lodash@^4.14.178":
-  version "4.14.178"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
-  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+"@types/lodash@^4.14.179":
+  version "4.14.179"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.179.tgz#490ec3288088c91295780237d2497a3aa9dfb5c5"
+  integrity sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==
 
 "@types/markdown-it@^12.2.3":
   version "12.2.3"


### PR DESCRIPTION
* Hopefully this commit addresses this issue. Unknown why this is happening.
* May require further investigation on why the backup-viewer is missing on the production site if issue still persist.