### PR TITLE
SwordRPC: add canImport(SwordRPC) around function invocation

### DIFF
--- a/NineAnimator/Controllers/DiscordPresenceController.swift
+++ b/NineAnimator/Controllers/DiscordPresenceController.swift
@@ -108,9 +108,11 @@ class DiscordPresenceController {
         if self.currentPresence != presence {
             self.currentPresence = presence
             NotificationCenter.default.post(name: .presenceControllerDidUpdatePresence, object: self)
+            #if canImport(SwordRPC)
             _queue.async {
                 [weak self] in self?._updatePresenceIfPossible()
             }
+            #endif
         }
     }
 }


### PR DESCRIPTION
This function is defined in the extension below, wrapped within the
if canImport(SwordRPC). on systems that don't have it, the project fails
to compile
